### PR TITLE
Removed "page" before {{each}} in the my-page.handlebars

### DIFF
--- a/assets/scripts/templates/my-page.handlebars
+++ b/assets/scripts/templates/my-page.handlebars
@@ -1,4 +1,4 @@
-page{{#each pages as |page|}}
+{{#each pages as |page|}}
 <div>
   <h1 data-id="{{page._id}}" class="my-page"> <small>{{page.name}}</small></h1>
   <ul data-id="{{page._id}}">


### PR DESCRIPTION
There was a "page" before the {{each}}.
This was appearing before every instance of my pages was being called.

-Matt M.